### PR TITLE
v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "NgRx",
     "Store",
     "Router",
-    "Redux"
+    "Redux",
+    "serialization"
   ],
   "author": "Jose Quintana <git.io/joseluisq>",
   "license": "MIT",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,8 @@ import { InjectionToken } from '@angular/core'
  * RouterStorePlus configuration
  */
 export class RouterStorePlusConfig {
-  /** A list of custom segment keys to map the "RouterStatePlus" payload segments */
-  public segmentKeys: string[]
+  /** Custom token segment keys to map the "RouterStatePlusActivatedSnapshot" payload segments */
+  public urlTokenSegmentKeys: string[]
 }
 
 export const STORE_ROUTE_PLUS_CONFIG = new InjectionToken<RouterStorePlusConfig>(
@@ -24,7 +24,7 @@ export function createConfig (
   _options: RouterStorePlusOptions
 ): RouterStorePlusConfig {
   const DEFAULT_OPTIONS: RouterStorePlusConfig = {
-    segmentKeys: []
+    urlTokenSegmentKeys: []
   }
 
   const options = typeof _options === 'function' ? _options() : _options

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,12 @@ export {
 } from './router-store.module'
 
 export {
-  RouterStatePlus
+  RouterStatePlusActivatedSnapshot
 } from './router-state'
 
 export {
-  ofRouterSegment
+  ofRouterNav,
+  ofRouterTokenSegmentsNav
 } from './router-operators'
 
 export {
@@ -17,3 +18,7 @@ export {
 export {
   RouterNavigationActionPlus
 } from './navigation.actions'
+
+export {
+  selectRouterState
+} from './navigation.selectors'

--- a/src/navigation.actions.ts
+++ b/src/navigation.actions.ts
@@ -1,12 +1,12 @@
 import { Action } from '@ngrx/store'
 import { ROUTER_NAVIGATION, RouterNavigationPayload } from '@ngrx/router-store'
 
-import { RouterStatePlus } from './router-state'
+import { RouterStatePlusActivatedSnapshot } from './router-state'
 
 /**
- * Router Navigation Action with a custom `RouterSegmentType` definition for the payload
+ * Router Navigation Action with a custom `RouterTokenSegments` definition for the payload
  */
-export class RouterNavigationActionPlus<RouterSegmentType> implements Action {
+export class RouterNavigationActionPlus<RouterTokenSegments> implements Action {
   public readonly type = ROUTER_NAVIGATION
-  constructor (public payload: RouterNavigationPayload<RouterStatePlus<RouterSegmentType>>) { }
+  constructor (public payload: RouterNavigationPayload<RouterStatePlusActivatedSnapshot<RouterTokenSegments>>) { }
 }

--- a/src/navigation.selectors.ts
+++ b/src/navigation.selectors.ts
@@ -1,0 +1,30 @@
+import { DEFAULT_ROUTER_FEATURENAME } from '@ngrx/router-store'
+
+import { RouterStatePlusActivatedSnapshot } from './router-state'
+
+interface RouterState<ISegments> {
+  [key: string]: {
+    state: RouterStatePlusActivatedSnapshot<ISegments>
+  }
+}
+
+type RootState<IRootState, ISegments> = IRootState & RouterState<ISegments>
+
+/**
+ * Selects current Router state feature
+ *
+ * @param featureName Router feature name (DEFAULT_ROUTER_FEATURENAME = 'router' by default)
+ */
+export const selectRouterState = <IRootState, ISegments = {}>(
+  featureName = DEFAULT_ROUTER_FEATURENAME
+) => (routerState: RootState<IRootState, ISegments>) => {
+  const feature = routerState[featureName]
+
+  // According to `RouterReducerState` type
+  // https://github.com/ngrx/platform/blob/master/modules/router-store/src/reducer.ts
+  if (feature && feature['state']) {
+    return feature['state']
+  } else {
+    throw new Error(`Router state feature '${featureName}' not found.`)
+  }
+}

--- a/src/router-operators.ts
+++ b/src/router-operators.ts
@@ -5,28 +5,51 @@ import { RouterNavigationActionPlus } from './navigation.actions'
 import { ofType } from '@ngrx/effects'
 
 /**
- * RxJS filter by Router Segment of the payload segments map
+ * RxJS filter by router navigation (ROUTER_NAVIGATION)
  *
- * @param key Segment key
- * @param value Segment value or Segment array expected
- * @returns Observable<RouterNavigationAction<CustomSegmentType>>
+ * @returns Observable<RouterNavigationAction<RouterTokenSegments>>
  */
-export function ofRouterSegment <T> (key: string, value: string | string[]) {
-  return (source: Observable<RouterNavigationActionPlus<T>>) => {
+export function ofRouterNav <RouterTokenSegments = {}> () {
+  return (source: Observable<RouterNavigationActionPlus<RouterTokenSegments>>) => {
     return source.pipe(
-      ofType<RouterNavigationActionPlus<T>>(ROUTER_NAVIGATION),
+      ofType<RouterNavigationActionPlus<RouterTokenSegments>>(ROUTER_NAVIGATION),
+      filter((routeAction) => routeAction.type === ROUTER_NAVIGATION)
+    )
+  }
+}
+
+/**
+ * RxJS filter by router token segment of the payload segments map (ROUTER_NAVIGATION)
+ *
+ * @param key Token segment key (mapping key)
+ * @param value Token segment value or values to matching. No comparing if `value` is 'undefined'
+ * @returns Observable<RouterNavigationAction<RouterTokenSegments>>
+ */
+export function ofRouterTokenSegmentsNav <RouterTokenSegments = {}> (key: string, value?: string | string[]) {
+  return (source: Observable<RouterNavigationActionPlus<RouterTokenSegments>>) => {
+    return source.pipe(
+      ofType<RouterNavigationActionPlus<RouterTokenSegments>>(ROUTER_NAVIGATION),
       filter((routeAction) => {
         const isRouteAction = routeAction.type === ROUTER_NAVIGATION
 
         if (isRouteAction) {
-          const { segments } = routeAction.payload.routerState
+          const { urlTokenSegments } = routeAction.payload.routerState
 
-          if (segments) {
-            if (Array.isArray(value)) {
-              return value.includes(segments[key])
-            } else {
-              return segments[key] === value
-            }
+          // return false if `key` is 'undefined'
+          if (!urlTokenSegments.hasOwnProperty(key)) {
+            return false
+          }
+
+          // no comparing if `value` is 'undefined'
+          if (typeof value === 'undefined') {
+            return true
+          }
+
+          // otherwise, check corresponding values
+          if (Array.isArray(value)) {
+            return value.includes(urlTokenSegments[key])
+          } else {
+            return (urlTokenSegments[key] === value)
           }
         }
 

--- a/src/router-state.ts
+++ b/src/router-state.ts
@@ -1,24 +1,47 @@
-import { Params } from '@angular/router'
+import { Type } from '@angular/core'
+import { ActivatedRouteSnapshot, Data, ParamMap, Params, Route, UrlSegment } from '@angular/router'
 
-/** RouterStateSegments intersection type (mapping segments object) */
-export type RouterStateSegments<T> = T & { [key: string]: string }
+/** RouterStateSegments intersection type (token segments mapping object) */
+export type RouterStateTokenSegments<T> = T & { [key: string]: string }
 
 /**
- * Represents a common interface for navigation payload (RouterNavigationPayload)
+ * Router activated snapshot state extended of `@angular/router/ActivatedRouteSnapshot`
+ *
+ * - ActivatedRouteSnapshot: https://angular.io/api/router/ActivatedRouteSnapshot#description
+ * - ActivatedRouteSnapshot source: https://github.com/angular/angular/blob/master/packages/router/src/router_state.ts
  */
-export interface RouterStatePlus<RouterSegmentType> {
+export interface RouterStatePlusActivatedSnapshot<RouterTokenSegments> {
   /** The string URL matched by this route */
   url: string
-
+  /** The URL segments matched by this route (ActivatedRouteSnapshot `url` prop) */
+  urlSegments: UrlSegment[]
+  /** The composed token segments mapping object (defined with custom keys) */
+  urlTokenSegments: RouterStateTokenSegments<RouterTokenSegments>
   /** The matrix parameters scoped to this route */
   params: Params
-
   /** The query parameters shared by all the routes */
   queryParams: Params
-
-  /**
-   * The composed segments mapping object (with custom keys) based on UrlSegments
-   * https://angular.io/api/router/UrlSegment
-   */
-  segments: RouterStateSegments<RouterSegmentType>
+  /** The URL fragment shared by all the routes */
+  fragment: string
+  /** The static and resolved data of this route */
+  data: Data
+  /** The outlet name of the route */
+  outlet: string
+  /** The component of the route */
+  component: Type<any> | string | null
+  /** The configuration used to match this route */
+  readonly routeConfig: Route | null
+  /** The root of the router state */
+  readonly root: ActivatedRouteSnapshot
+  /** The parent of this route in the router state tree */
+  readonly parent: ActivatedRouteSnapshot | null
+  /** The first child of this route in the router state tree */
+  readonly firstChild: ActivatedRouteSnapshot | null
+  /** The children of this route in the router state tree */
+  readonly children: ActivatedRouteSnapshot[]
+  /** The path from the root of the router state tree to this route */
+  readonly pathFromRoot: ActivatedRouteSnapshot[]
+  readonly paramMap: ParamMap
+  readonly queryParamMap: ParamMap
+  toString (): string
 }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -3,14 +3,14 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router'
 import { RouterStateSerializer } from '@ngrx/router-store'
 
 import { RouterStorePlusConfig, STORE_ROUTE_PLUS_CONFIG } from './config'
-import { RouterStatePlus, RouterStateSegments } from './router-state'
+import { RouterStatePlusActivatedSnapshot, RouterStateTokenSegments } from './router-state'
 
 /**
- * Router serializer that takes a `RouterStateSnapshot` and return a composed state object (RouterStatePlus)
+ * Router erializer that takes a `RouterStateSnapshot` and return an `RouterStatePlusActivatedSnapshot` object
  */
 @Injectable()
-export class RouterStateSerializerPlus<RouterSegmentType> implements
-  RouterStateSerializer<RouterStatePlus<RouterSegmentType>> {
+export class RouterStateSerializerPlus<RouterTokenSegments> implements
+  RouterStateSerializer<RouterStatePlusActivatedSnapshot<RouterTokenSegments>> {
 
   private readonly config: RouterStorePlusConfig
 
@@ -19,42 +19,56 @@ export class RouterStateSerializerPlus<RouterSegmentType> implements
   }
 
   public serialize (routerState: RouterStateSnapshot) {
-    return this.serializeWithSegments(routerState, this.config.segmentKeys)
+    return this.serializeWithSegments(routerState, this.config.urlTokenSegmentKeys)
   }
 
   /**
    * Serialize a `RouterStateSnapshot` into composed object
    *
-   * @param routerState
-   * @param segmentKeys
-   * @returns RouterStateUrl with segments
+   * @param routerState Router state
+   * @param segmentKeys Router segment keys
    */
   public serializeWithSegments (
     routerState: RouterStateSnapshot,
     segmentKeys: string[]
-  ): RouterStatePlus<RouterSegmentType> {
+  ): RouterStatePlusActivatedSnapshot<RouterTokenSegments> {
     let route = routerState.root
 
     if (route.firstChild) {
       route = route.firstChild
     }
 
-    const { url, root: { queryParams } } = routerState
-    const { params } = route
-    const segments = this.createSegmentsURI<RouterSegmentType>(route, segmentKeys)
+    const urlTokenSegments = this.createUrlTokenSegments<RouterTokenSegments>(route, segmentKeys)
 
-    return { url, params, queryParams, segments }
+    return {
+      url: routerState.url,
+      urlSegments: route.url,
+      urlTokenSegments,
+      params: route.params,
+      queryParams: route.queryParams,
+      fragment: route.fragment,
+      data: route.data,
+      outlet: route.outlet,
+      component: route.component,
+      routeConfig: route.routeConfig,
+      root: route.root,
+      parent: route.parent,
+      firstChild: route.firstChild,
+      children: route.children,
+      pathFromRoot: route.pathFromRoot,
+      paramMap: route.paramMap,
+      queryParamMap: route.queryParamMap
+    }
   }
 
   /**
-   * Create a composed segment object
+   * Create a composed mapping object by token segment urls
    *
-   * @param route
-   * @param keys
-   * @returns Return a segments object
+   * @param route Route activated snapshot
+   * @param keys Token segment keys
    */
-  private createSegmentsURI<T = {}> (route: ActivatedRouteSnapshot, keys: string[]): RouterStateSegments<T> {
-    const segments = {} as RouterStateSegments<T>
+  private createUrlTokenSegments<T = {}> (route: ActivatedRouteSnapshot, keys: string[]): RouterStateTokenSegments<T> {
+    const segments = {} as RouterStateTokenSegments<T>
 
     keys.forEach((key, index) => {
       const segment = route.url[index] || null


### PR DESCRIPTION
## Changelog

### Modules

__RouterStorePlusModule__ is the main module to importing into your app.

### Serializer

[Router state serialization](https://ngrx.io/guide/router-store/configuration#custom-router-state-serializer) is out of the box.

### Router State Plus

[`RouterStatePlusActivatedSnapshot<RouterTokenSegments>`](./src/router-state.ts) is router activated state interface that extend of [Angular ActivatedRouteSnapshot](https://angular.io/api/router/ActivatedRouteSnapshot#description).

But there are only three differences at properties level:

- `url` type is `string` (updated prop)
- `urlSegments` type is `UrlSegment[]` (new prop). `url` in `ActivatedRouteSnapshot`.
- `urlTokenSegments` is RouterStateTokenSegments<RouterTokenSegments> (new prop)

Since it's based on `ActivatedRouteSnapshot`, you can also access to their properties as usual with the exception that `url` was moved to `urlSegments` and `url` is now current string url.

### Operators

[RxJS](https://angular.io/guide/rx-library) operators for using with effects:

- __ofRouterNav__: Operator to filter by router navigation ([NgRx ROUTER_NAVIGATION](https://ngrx.io/guide/router-store/actions)).
- __ofRouterTokenSegmentsNav__: Operator to filter by router navigation with token segment checks (E.g `page/:token_segment`).

### Selectors

- __selectRouterState__: Selects current Router state feature.